### PR TITLE
Make react preprocessor compatible with latest react-tools

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ var ReactPreprocessor = function(args, config, logger) {
         log.debug('Processing "%s".', file.originalPath);
         file.path = transformPath(file.originalPath);
 
-        done(require('react-tools').transform(content));
+        done(require('react-tools').transform(content, {harmony: config.harmony}));
     };
 };
 

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "grunt-simple-mocha": "~0.4",
     "grunt-karma": "~0.7",
     "chai": "~1.5",
-    "react-tools": ">=0.1"
+    "react-tools": ">=0.12"
   },
   "contributors": []
 }

--- a/test/unit/hello-messageSpec.js
+++ b/test/unit/hello-messageSpec.js
@@ -26,7 +26,7 @@ describe('hello-message', function() {
         var file = new FileMock('test.jsx');
 
         this.preprocessor('/** @jsx React.DOM */ <div>Test</div>;', file, function(content) {
-            expect(content).to.be.equal('/** @jsx React.DOM */ React.DOM.div(null, "Test");');
+            expect(content).to.be.equal('/** @jsx React.DOM */ React.createElement("div", null, "Test");');
         });
     });
 

--- a/test/unit/hello-messageSpec.js
+++ b/test/unit/hello-messageSpec.js
@@ -50,4 +50,15 @@ describe('hello-message', function() {
 
         expect(file.path).to.be.equal('test.ext');
     });
+
+    it('should allow to pass harmony option', function() {
+        var file = new FileMock('test.jsx');
+        this.preprocessor = new ReactPreprocessor({}, {
+            harmony: true,
+        }, new LoggerMock());
+
+        this.preprocessor('<div onClick={e => alert(e)} />', file, function(content) {
+            expect(content).to.be.equal('React.createElement("div", {onClick: (function(e)  {return alert(e);})})');
+        });
+    });
 });


### PR DESCRIPTION
After a clean install with latest react-tools (0.12.2), I found that one of the unit tests was failing. 

This pull request addresses that and bumps the dependency version.
