### PR TITLE
Allow passing harmony option to enable some ES6 features

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,21 @@ module.exports = function(config) {
 };
 ```
 
+You can enable ES6 features by setting harmony option to true:
+```js
+// karma.conf.js
+module.exports = function(config) {
+  config.set({
+    preprocessors: {
+      '**/*.jsx': ['react']
+    },
+    reactPreprocessor: {
+        harmony: true
+    }
+  });
+};
+```
+
 You can look at karma.conf.js how example
 
 For more information on Karma see the [homepage].

--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ var ReactPreprocessor = function(args, config, logger) {
         log.debug('Processing "%s".', file.originalPath);
         file.path = transformPath(file.originalPath);
 
-        done(require('react-tools').transform(content));
+        done(require('react-tools').transform(content, {harmony: config.harmony}));
     };
 };
 

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "grunt-simple-mocha": "~0.4",
     "grunt-karma": "~0.7",
     "chai": "~1.5",
-    "react-tools": ">=0.1"
+    "react-tools": ">=0.12"
   },
   "contributors": []
 }

--- a/test/unit/hello-messageSpec.js
+++ b/test/unit/hello-messageSpec.js
@@ -26,7 +26,7 @@ describe('hello-message', function() {
         var file = new FileMock('test.jsx');
 
         this.preprocessor('/** @jsx React.DOM */ <div>Test</div>;', file, function(content) {
-            expect(content).to.be.equal('/** @jsx React.DOM */ React.DOM.div(null, "Test");');
+            expect(content).to.be.equal('/** @jsx React.DOM */ React.createElement("div", null, "Test");');
         });
     });
 

--- a/test/unit/hello-messageSpec.js
+++ b/test/unit/hello-messageSpec.js
@@ -50,4 +50,15 @@ describe('hello-message', function() {
 
         expect(file.path).to.be.equal('test.ext');
     });
+
+    it('should allow to pass harmony option', function() {
+        var file = new FileMock('test.jsx');
+        this.preprocessor = new ReactPreprocessor({}, {
+            harmony: true,
+        }, new LoggerMock());
+
+        this.preprocessor('<div onClick={e => alert(e)} />', file, function(content) {
+            expect(content).to.be.equal('React.createElement("div", {onClick: (function(e)  {return alert(e);})})');
+        });
+    });
 });


### PR DESCRIPTION
This pull request makes it possible to pass `harmony: true` option to react-tools, in order to enable features like fat arrows and classes from ES6.

This pull request also includes code from pull request #1, because the harmony option is supported in React since version 0.10.
